### PR TITLE
fix `make clean` command

### DIFF
--- a/makefile
+++ b/makefile
@@ -58,7 +58,7 @@ SCRIPTS := build-scripts
 all: dist
 
 clean:
-	git clean -dX  # remove ignored files and directories
+	git clean -dfX  # remove ignored files and directories
 	-rm -r '$(BUILD)'
 
 checkin:


### PR DESCRIPTION
`git clean` doesn't delete anything unless `-f` is passed (or `clean.requireForce` is set to `false`). This change makes `make clean` really do the cleanup.